### PR TITLE
fix iconv utf8 conversion code

### DIFF
--- a/bin/build_callhome.sh
+++ b/bin/build_callhome.sh
@@ -13,7 +13,7 @@ for C in $(cd mapping; ls callhome*); do
   for F in $(cat mapping/$C | cut -d' ' -f1 | uniq); do
     echo "## FILE $F"
     cat $1/transcrp/*/$F.txt | 
-    iconv -f iso8859-1 -t utf8 | 
+    iconv -f iso8859-1 -t utf-8 | 
     cut -f 4- -d \ | 
     $BINDIR/strip_markup.pl 
   done | $BINDIR/map_transcription.py mapping/$C > $TARGETDIR/$C.es


### PR DESCRIPTION
Hi, 

Turns out there are two versions of iconv - 
```
iconv (GNU libiconv 1.15)
``` 
and 
```
iconv (GNU libc) 2.17
```

Both versions support `utf-8` but only the second version supports `utf8`. I think both the encodings are the same - [here](https://stackoverflow.com/questions/19840849/what-is-the-difference-between-utf8-and-utf-8#:~:text=There%20is%20no%20difference%20between,the%20most%20common%20Unicode%20encoding.) 

If you think that's correct, could you accept the PR? 

Thanks